### PR TITLE
Providing expanded support for persistence. Includes a simple way to …

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,8 @@ http://iam.example.com/admin
 http://iam.example.com/openam
 #### LDAP (use curl or LDAP browser) (cn=directory manager/password)
 ldap://iam.example.com/dc=example,dc=com
+
+## Enabling/Disabling Persistence
+By default, the containers do not include peristence and data in openAM and openDJ will be lost if the containers are destoyed.
+Scripts are provided to help make it easy to enable and disable peristence.
+`$ ./make-persistent.sh` will modify the docker-compose file in place to add support for persistence and `$ ./clear-persistent.sh` will remove it as well as delete the persistnece folders that have been created.

--- a/clear-persistent.sh
+++ b/clear-persistent.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+sudo rm -rf  persistence
+
+sed -i 's/\(.* #Persistence\)$/#Persistence\1/' docker-compose.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,14 @@
 repo:
  image: debian:jessie
- volumes:
-  - .:/opt/repo
+# volumes:
+#   - $PWD:/opt/repo
  command: /bin/true
 opendj:
  image: conductdocker/opendj-nightly
  volumes_from:
   - repo
+#Persistence volumes: #Persistence
+#Persistence  - $PWD/persistence/opendj_data:/opt/opendj/instances/instance1 #Persistence
 openam:
  image: conductdocker/openam-nightly
  links:
@@ -18,8 +20,10 @@ postgres:
  environment:
   - POSTGRES_PASSWORD=openidm
   - POSTGRES_USER=openidm
- volumes:
-  - ./postgres:/docker-entrypoint-initdb.d
+#Persistence  - PGDATA=/usr/local/postgresql/data/pgdata #Persistence
+ volumes: 
+  - $PWD/postgres:/docker-entrypoint-initdb.d
+#Persistence  - $PWD/persistence/pgdata:/usr/local/postgresql/data #Persistence
 openidm:
  image: conductdocker/openidm-nightly
  links:
@@ -27,6 +31,8 @@ openidm:
   - postgres:postgres
  volumes_from:
   - repo
+#Persistence volumes: #Persistence
+#Persistence  - $PWD/persistence/openidm:/opt/openidm #Persistence
 iam.example.com:
  container_name: iam.example.com
  image: conductdocker/haproxy-iam

--- a/make-persistent.sh
+++ b/make-persistent.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+mkdir -p persistence/opendj_data
+mkdir -p persistence/pgdata
+mkdir -p persistence/postgres
+mkdir -p persistence/repo
+mkdir -p persistence/openidm
+
+sed -i 's/^#Persistence\(.*\)/\1/' docker-compose.yml


### PR DESCRIPTION
…enable and disable within the docker-compose file as well as stubs for which entries are persistence related.

Note: the shared 'repo' has been removed as the openidm files that are included as part of the git repo seem to cause issues if used with recent nightlies.